### PR TITLE
Update npp.sls winrepo example

### DIFF
--- a/npp.sls
+++ b/npp.sls
@@ -1,7 +1,7 @@
 npp:
    6.4.2:
       installer: 'http://download.tuxfamily.org/notepadplus/6.4.2/npp.6.4.2.Installer.exe'
-      full_name: Notepad ++ 6.4.2
+      full_name: Notepad++
       reboot: False
       install_flags: ' /S'
       uninstaller: '%ProgramFiles(x86)%/Notepad++/uninstall.exe'


### PR DESCRIPTION
`full_name` changed so that the package can be verified properly when highstate is run. See the [Windows Software Repo](https://salt.readthedocs.org/en/latest/ref/windows-package-manager.html) documentation for more info. 
