### PR TITLE
Update jre.sls

### DIFF
--- a/jre.sls
+++ b/jre.sls
@@ -4,5 +4,11 @@ jre:
     full_name: 'Java Runtime Enviorment x86_64 (7u51-b13)'
     reboot: False
     install_flags: ' /s '
+    
+  7.0.510:
+    installer: 'salt://win/repo/jre/jre-7u51-windows-i586.exe'
+    full_name: 'Java 7 Update 51'
+    reboot: False
+    uninstall_flags: ' /s '
 
 


### PR DESCRIPTION
Allows Windows Minions to get 32-bit JRE in an environment where the minion has no internet access.  The original entry (7.51.13) did not work for my setup which has a 64-bit Ubuntu Master and a 64-bit Windows 7 Minion.  This file assumes that the installer is already on the Master, located in salt://win/repo/jre/.

Reason for addition: At least in my setup, the original state did not work.  When the 64-bit exe was sent to my minions, it had been modified to an HTML file that said "Unauthorized Access", and then my machine threw an error message stating that the file was a 16-bit installer, and is not compatible with a 64-bit operating system.  I believe this is because when you download this specific exe using a browser, you need to manually accept the license before you can download, and this operation had not been performed on my minion.

System Specifics:
Salt Master: Ubuntu 12.04 64-bit (VM)
Salt Minion: Windows 7 64-bit (VM)
Both VMs run on a MacBook Pro (Late 2008) 10.7.5

Alternate Solutions:
Getting the JRE onto Windows Minions could be done by using a file.recurse on the JRE tarball and putting it into the appropriate directory (%ProgramFiles(x86)/Java/)
