### PR TITLE
Add python2_x86 (2.7.8)

### DIFF
--- a/python2_x86.sls
+++ b/python2_x86.sls
@@ -1,0 +1,10 @@
+python2_x86:
+  2.7.8150:
+    full_name: 'Python 2.7.8'
+    msiexec: True
+    installer: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'
+    install_flags: '/qn /norestart ALLUSERS=1'
+    uninstaller: 'http://www.python.org/ftp/python/2.7.8/python-2.7.8.msi'
+    uninstall_flags: '/qn'
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
Note ALLUSERS=1. Otherwise, the Python installer does a per-user install, which salt doesn't detect.
