### PR TITLE
Updated EMET version to 5.1

### DIFF
--- a/emet.sls
+++ b/emet.sls
@@ -1,9 +1,9 @@
 Emet:
-  5.0:
-    installer: 'http://download.microsoft.com/download/A/A/8/AA853FAE-7608-462E-B166-45B0F065BA13/EMET%20Setup.msi'
-    full_name: 'EMET 5.0'
+  5.1:
+    installer: 'http://download.microsoft.com/download/A/A/8/AA853FAE-7608-462E-B166-45B0F065BA13/EMET%205.1%20Setup.msi'
+    full_name: 'EMET 5.1'
     reboot: False
     install_flags: ' ALLUSERS=1 /quiet /qn /norestart'
     msiexec: True
-    uninstaller: 'http://download.microsoft.com/download/A/A/8/AA853FAE-7608-462E-B166-45B0F065BA13/EMET%20Setup.msi'
+    uninstaller: 'http://download.microsoft.com/download/A/A/8/AA853FAE-7608-462E-B166-45B0F065BA13/EMET%205.1%20Setup.msi'
     uninstall_flags: ' /qn'


### PR DESCRIPTION
Microsoft has deprecated EMET 5.0. It no longer appears available for download, so it has been removed from the package definition.