### PR TITLE
Update blender.sls to ver. 2.73a

### DIFF
--- a/blender.sls
+++ b/blender.sls
@@ -1,4 +1,11 @@
 blender:
+  2.73a: 
+    installer: 'http://ftp.nluug.nl/pub/graphics/blender/release/Blender2.73/blender-2.73a-windows64.exe'
+    full_name:  'Blender'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles%\Blender Foundation\Blender\uninstall.exe'
+    uninstall_flags: '/S'  
   2.68:
     installer: 'http://ftp.nluug.nl/pub/graphics/blender/release//Blender2.68/blender-2.68-windows32.exe'
     full_name:  'Blender'


### PR DESCRIPTION
Updated blender.sls top latest released ver. 2.73a (64-bit) - the old installer had the 32 bit version being installed on the 64-bit win OS.