### PR TITLE
Update chrome.sls to ver. 66.41.32862

### DIFF
--- a/chrome.sls
+++ b/chrome.sls
@@ -1,6 +1,6 @@
 # Source: http://www.google.nl/intl/en/chrome/business/browser/admin/
 chrome:
-  65.130.49228:
+  66.41.32862:
     installer: 'https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi'
     full_name: 'Google Chrome'
     reboot: False


### PR DESCRIPTION
Updated chrome version number to 66.41.32862. but the download URL keeps pointing to the latest version of chrome and the actual installed version number will hence keep going up and up all the time anyway