### PR TITLE
fixed 'broken' download URL

### DIFF
--- a/audacity.sls
+++ b/audacity.sls
@@ -1,6 +1,6 @@
 audacity:
   2.0.6:
-    installer: http://sourceforge.net/projects/audacity/files/audacity/2.0.6/audacity-win-2.0.6.exe/download
+    installer: 'http://heanet.dl.sourceforge.net/project/audacity/audacity/2.0.6/audacity-win-2.0.6.exe'
     full_name: Audacity 2.0.6
     locale: en_US
     reboot: False


### PR DESCRIPTION
the sourceforge download URLs ending in /download cause salt to create a dl file called download with no suffix and it can't execute or install the files. so I had to take a regional final download link instead of the one that would have geographically distriubuted  the DL to a geographically 'local' link