### PR TITLE
Create initial gpg4win-light.sls ver. 2.2.3

### DIFF
--- a/gpg4win-light.sls
+++ b/gpg4win-light.sls
@@ -1,0 +1,9 @@
+gpg4win-light:
+  2.2.3:
+    installer: 'http://files.gpg4win.org/gpg4win-light-2.2.3.exe'
+    full_name: 'Gpg4Win (2.2.3)'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles%\Blender Foundation\Blender\uninstall.exe'
+    uninstall_flags: '/S'
+    


### PR DESCRIPTION
Created initial gpg4win-light.sls ver. 2.2.3 (silent switch /S does not fully suppress all prompts - bug submitted upstream, until upstream fix this, the light version won't be installable by  salt)