### PR TITLE
Create initial gpg4win-light.sls ver. 2.2.3

### DIFF
--- a/gpg4win-light.sls
+++ b/gpg4win-light.sls
@@ -1,0 +1,8 @@
+gpg4win-light:
+  2.2.3:
+    installer: 'http://files.gpg4win.org/gpg4win-light-2.2.3.exe'
+    full_name: 'Gpg4Win (2.2.3)'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles%\GNU\GnuPG\gpg4win-uninstall.exe'
+    uninstall_flags: '/S'


### PR DESCRIPTION
Created initial gpg4win-light.sls ver. 2.2.3. (Note! This 'light' gpg4win package won't actually be installed by salt, as the upstream folks need to fix the /S silent installer switch first.