### PR TITLE
Create initial truecrypt.sls ver. 7.1a

### DIFF
--- a/truecrypt.sls
+++ b/truecrypt.sls
@@ -1,0 +1,9 @@
+truecrypt:
+  7.1a:
+    installer: 'https://download.truecrypt.ch/current/TrueCrypt%20Setup%207.1a.exe'
+    full_name: 'TrueCrypt 7.1a'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles(x86)%\Truecrypt\uninstall.exe'
+    uninstall_flags: '/S'
+ 


### PR DESCRIPTION
Created initial truecrypt.sls ver. 7.1a. (Note! There is however a issue with the /S instaler switch, until that problem is overcome, it won't be easily installable using salt. I am creating this sls file and will then open up an issue on the faulty installer switch.)