### PR TITLE
commented upstream installer bug work-around

### DIFF
--- a/gpg4win-light.sls
+++ b/gpg4win-light.sls
@@ -6,3 +6,8 @@ gpg4win-light:
     install_flags: '/S'
     uninstaller: '%ProgramFiles%\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
+#
+# Note: this 2.2.1 light installer has a bug and it needs to be fixed upstream 
+# Here are work around instructions under Issue #113 in the meantime
+# https://github.com/saltstack/salt-winrepo/issues/113#issuecomment-72837987
+#

--- a/gpg4win-light.sls
+++ b/gpg4win-light.sls
@@ -7,7 +7,7 @@ gpg4win-light:
     uninstaller: '%ProgramFiles%\GNU\GnuPG\gpg4win-uninstall.exe'
     uninstall_flags: '/S'
 #
-# Note: this 2.2.1 light installer has a bug and it needs to be fixed upstream 
+# Note: this 2.2.3 light installer has a bug and it needs to be fixed upstream 
 # Here are work around instructions under Issue #113 in the meantime
 # https://github.com/saltstack/salt-winrepo/issues/113#issuecomment-72837987
 #


### PR DESCRIPTION
The 2.2.1 "light" installer has an upstream bug. I added a comment to point to the workaround into the sls file.