### PR TITLE
Create initial MS fciv.sls ver. 2.05

### DIFF
--- a/fciv.sls
+++ b/fciv.sls
@@ -1,0 +1,9 @@
+fciv:
+  2.05:
+    installer: 'http://download.microsoft.com/download/c/f/4/cf454ae0-a4bb-4123-8333-a1b6737712f7/Windows-KB841290-x86-ENU.exe'
+    full_name: 'File Checksum Integrity Verifier version 2.05'
+    reboot: False
+    install_flags: '/q /c /t:%SystemRoot%'
+    uninstaller: 'cmd'
+    uninstall_flags: '/c del /Q /F %SystemRoot%\fciv.exe'
+    


### PR DESCRIPTION
Created initial MS fciv.sls ver. 2.05. Don't really like this way of installing software. dropping it in c:\windows directory. but salt needs to learn to deal with apps that do not have an installer, until then thsi will have to do. plus the fciv.xe is not a dangerous executable prone to exploitation and I do have a tested and working uninstaller for salt , so if salt tries to remove it , that will succeed and put the machine back to how it was.