### PR TITLE
Create initial mysql-installer-community.sls ver. 1.4.3.0

### DIFF
--- a/mysql-installer-community.sls
+++ b/mysql-installer-community.sls
@@ -1,0 +1,13 @@
+mysql-installer-community:
+ 1.4.3.0:
+    installer: 'http://cdn.mysql.com/Downloads/MySQLInstaller/mysql-installer-community-5.6.23.0.msi'
+     full_name: 'MySQL Installer - Community'
+     reboot: False
+     install_flags: '/quiet /norestart'
+     msiexec: True
+     uninstaller: 'msiexec.exe'
+     uninstall_flags: '/qn /x {1BF2A017-1067-43B9-873F-9F718CBD97BC}'
+#
+# Read for MySQL Server 5.6.23.0 Community installation instructions:
+# https://dev.mysql.com/doc/refman/5.6/en/mysql-installer-gui.html
+# https://dev.mysql.com/doc/refman/5.6/en/MySQLInstallerConsole.html


### PR DESCRIPTION
Created initial mysql-installer-community.sls ver. 1.4.3.0.
This will enable installation of all sorts of constellations of MySQL 5.6.23.0, Developer default, Server Only, Client only, Full and Custom.  

For MySQL Server 5.6.23.0 Community installation instructions read:
https://dev.mysql.com/doc/refman/5.6/en/mysql-installer-gui.html
https://dev.mysql.com/doc/refman/5.6/en/MySQLInstallerConsole.html