### PR TITLE
Rename ultravnc.sls to ultravnc_x86.sls and update to ver. 1.2.09

### DIFF
--- a/ultravnc_x86.sls
+++ b/ultravnc_x86.sls
@@ -1,0 +1,18 @@
+ultravnc_x86:
+  1.2.05:
+    installer: 'http://www.uvnc.eu/download/1205/UltraVNC_1_2_05_X86_Setup.exe'
+    full_name: 'UltraVnc'
+    reboot: False
+    locale: en_US
+    install_flags: '/VERYSILENT /NORESTART'
+    uninstaller: '%ProgramFiles(x86)%/uvnc bvba/UltraVNC/unins000.exe'
+    uninstall_flags: '/VERYSILENT /NORESTART'
+   1.1.9.6:
+     installer: 'http://www.uvnc.eu/1196/UltraVNC_1_1_9_X86_Setup.exe'
+     full_name: 'UltraVnc'
+     reboot: False
+     locale: en_US
+     install_flags: ' /verysilent /norestart '
+     uninstaller: '%programfiles(x86)%/uvnc bvba/UltraVNC/unins000.exe'
+     uninstall_flags: ' /verysilent '  
+    


### PR DESCRIPTION
Renamed old pre-existing ultravnc.sls to ultravnc_x86.sls and updated to ver. 1.2.09, as well as fixing typo in path of ver. 1.1.9.6 uninstaller.