### PR TITLE
Create initial irfanview-plugins.sls ver. 4.38

### DIFF
--- a/irfanview-plugins.sls
+++ b/irfanview-plugins.sls
@@ -1,0 +1,9 @@
+irfanview-plugins:
+  4.38:
+    installer: 'http://www.tucows.com/download/windows/files/irfanview_plugins_438_setup.exe'
+    full_name: 'Irfanview Plugins 4.38'
+    reboot: False
+    install_flags: '/silent'
+    uninstaller: ''
+    uninstall_flags: '' 
+    


### PR DESCRIPTION
Create initial irfanview-plugins.sls ver. 4.38
the plugins do not have an un-installer that I can find. to uninstall them one has to uninstall IrfanView 4.38 itself.