### PR TITLE
fix syntax error - misaligned block in xampp.sls

### DIFF
--- a/xampp.sls
+++ b/xampp.sls
@@ -1,6 +1,6 @@
 xampp:
   5.6.3.0:
-    installer: 'http://heanet.dl.sourceforge.net/project/xampp/XAMPP%20Windows/5.6.3/xampp-win32-5.6.3-0-VC11-installer.exe'
+     installer: 'http://heanet.dl.sourceforge.net/project/xampp/XAMPP%20Windows/5.6.3/xampp-win32-5.6.3-0-VC11-installer.exe'
      full_name: 'XAMPP 5.6.3'
      reboot: False
      install_flags: '--mode unattended'


### PR DESCRIPTION
xampp.sls was misformatted and broke winrepo.genrepo . This fixes #151