### PR TITLE
fixing syntax of ccleaner.sls blocks were misaligned

### DIFF
--- a/ccleaner.sls
+++ b/ccleaner.sls
@@ -1,9 +1,9 @@
 ccleaner:
   5.02.5101:
     installer: 'http://download.piriform.com/ccsetup502.exe'
-     full_name: 'CCleaner 5.02'
-     reboot: False
-     install_flags: '/S'
-     uninstaller: '%ProgramFiles%\CCleaner\uninst.exe'
-     uninstall_flags: '/S'
+    full_name: 'CCleaner 5.02'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles%\CCleaner\uninst.exe'
+    uninstall_flags: '/S'
      


### PR DESCRIPTION
fixing syntax of ccleaner.sls blocks were misaligned . this fixes issue #155