### PR TITLE
Create initial spybot.sls ver. 2.4

### DIFF
--- a/spybot.sls
+++ b/spybot.sls
@@ -1,0 +1,12 @@
+# Source: http://www.safer-networking.org/
+spybot:
+  2.4:
+    installer: 'http://spybotupdates.com/files/spybot-2.4.exe'
+    full_name: 'Spybot - Search & Destroy'
+    reboot: False
+    install_flags: '/VERYSILENT /SuppressMsgGBoxes /NoRestart /SP-'
+    uninstaller: '%ProgramFiles(x86)%\Spybot - Search & Destroy 2\unins000.exe'
+    uninstall_flags: '/VERYSILENT /SuppressMsgGBoxes /NoRestart /SP-'
+# alternative download URLs
+# http://www.spybotupdates.biz/files/spybot-2.4.exe
+# http://spybot-mirror.com/files/spybot-2.4.exe


### PR DESCRIPTION
Created initial spybot.sls ver. 2.4

The un-installer opens up a dialogue and won't proceed, since it is invisible. Logged a bug upstream, but they might not be inclined to 'fix' this.