### PR TITLE
Create initial gpu-z.sls ver. 0.8.1

### DIFF
--- a/gpu-z.sls
+++ b/gpu-z.sls
@@ -1,0 +1,14 @@
+# Source: http://www.techpowerup.com/gpuz/
+gpu-z:
+  0.8.1:
+    installer: 'http://us1-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.1.exe'
+    full_name: 'GPU-Z 0.8.1'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%ProgramFiles(x86)%\GPU-Z\uninstall.exe'
+    uninstall_flags: '/S'
+# alternate DL URLs
+# http://uk1-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.1.exe
+# http://us2-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.1.exe
+# http://de1-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.1.exe
+# http://nl2-dl.techpowerup.com/SysInfo/GPU-Z/GPU-Z.0.8.1.exe


### PR DESCRIPTION
Created initial gpu-z.sls ver. 0.8.1
This installer needs a bit of work. the /S switch will launch it and then the actual installer needs to be laucnhed from it's menu. This will need automating for this to work with salt. But on the flipside the /S for unistall does work.
RFE logged upstream for them to add a properly silent  /S switch to installer.