### PR TITLE
Updates the version and full_name strings for ms-vcpp-2012-redist

### DIFF
--- a/ms-vcpp-2012-redist.sls
+++ b/ms-vcpp-2012-redist.sls
@@ -1,7 +1,7 @@
 ms-vcpp-2012-redist:
-  11.0.61030:
+  11.0.61030.0:
     installer: 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe'
-    full_name: 'Microsoft Visual C++ 2012 Redistributable (x64) 11.0.61030'
+    full_name: 'Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030'
     reboot: False
     install_flags: '/quiet /norestart'
     uninstaller: 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe'

--- a/ms-vcpp-2012-redist_x86.sls
+++ b/ms-vcpp-2012-redist_x86.sls
@@ -1,7 +1,7 @@
 ms-vcpp-2012-redist_x86:
-  11.0.61030:
+  11.0.61030.0:
     installer: 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe'
-    full_name: 'Microsoft Visual C++ 2012 Redistributable (x86) 11.0.61030'
+    full_name: 'Microsoft Visual C++ 2012 Redistributable (x86) - 11.0.61030'
     reboot: False
     install_flags: '/quiet /norestart'
     uninstaller: 'http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe'


### PR DESCRIPTION
The packages were installing, but salt was reporting errors. I determined
that it was due to the version and full_name string mismatch from
pkg.list_pkgs

This pull request includes the patch for that. This was tested on 
Windows 8.1 and Windows Server 2012