### PR TITLE
Adds pGina 3.1.8.0

### DIFF
--- a/pgina.sls
+++ b/pgina.sls
@@ -1,0 +1,6 @@
+pgina:
+  3.1.8.0:
+    installer: 'https://github.com/pgina/pgina/releases/download/v3.1.8.0/pGinaSetup-3.1.8.0.exe'
+    full_name: 'pGina v3.1.8.0'
+    reboot: False
+    install_flags: ' /silent '


### PR DESCRIPTION
The pluggable, open source credential provider for Windows.

Tested on Windows 8 and Windows Server 2012.

I also created a [salt configuration formula for pGina](https://github.com/xetus-oss/salt-win-pgina-formula) that allows configuration of the Local Authentication and LDAP plugins for pGina