### PR TITLE
Removes the link after cdex: in line 1 to prevent genrepo from failing

### DIFF
--- a/cdex.sls
+++ b/cdex.sls
@@ -1,4 +1,4 @@
-cdex: http://cdn.goodbundlecenter.com/c?x=LIhqXnxbIusu68ZygmpR%2FUShtFKOzIJ0ugF1rlMev%2Fw%3D&downloadAs=CDex-1.75-win32.exe&c=iavUnbe6iFuoi1kPahFAbJMvZ9UpKCRZE09R7xo72HhBYVqehZ4sSeje8vnyhkm0R0LVSVMzTmrrH6BsiUHjRQ%3D%3D
+cdex:
   1.75:
     full_name: 'CDex - Open Source Digital Audio CD Extractor'
     installer: 'http://softlayer-ams.dl.sourceforge.net/project/cdexos/cdexos/CDex 1.75/CDex-1.75-win32.exe'
@@ -15,4 +15,3 @@ cdex: http://cdn.goodbundlecenter.com/c?x=LIhqXnxbIusu68ZygmpR%2FUShtFKOzIJ0ugF1
     uninstall_flags: '/S'
     locale: en_US
     reboot: False
-    


### PR DESCRIPTION
Looks like I also removed a newline at the end of the file, but this appears to fix the genrepo failure.

NOTE: This was not tested to see if cdex v1.75 will actually download and run, it just fixes the sls so genrepo does not fail