### PR TITLE
Update salt-minion.sls to ver. 2015.3 and 2015.3-2

### DIFF
--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -1,7 +1,23 @@
 salt-minion:
-  2015.5.2-2:
-    installer: 'https://docs.saltstack.com/downloads/Salt-Minion-2015.5.2-2-AMD64-Setup.exe'
-    full_name: 'Salt Minion v2015.5.2-2'
+  2015.5.3-2:
+    installer: 'https://docs.saltstack.com/downloads/Salt-Minion-2015.5.3-2-AMD64-Setup.exe'
+    full_name: 'Salt Minion v2015.5.3-2'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: 'C:\salt\uninst.exe'
+    uninstall_flags: '/S'
+    refresh: true
+  2015.5.3:
+    installer: 'https://docs.saltstack.com/downloads/Salt-Minion-2015.5.3-AMD64-Setup.exe'
+    full_name: 'Salt Minion v2015.5.3'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: 'C:\salt\uninst.exe'
+    uninstall_flags: '/S'
+    refresh: true
+  2015.5.2:
+    installer: 'https://docs.saltstack.com/downloads/Salt-Minion-2015.5.2-AMD64-Setup.exe'
+    full_name: 'Salt Minion v2015.5.2'
     reboot: False
     install_flags: '/S'
     uninstaller: 'C:\salt\uninst.exe'


### PR DESCRIPTION
Updated salt-minion.sls to ver. 2015.3 and 2015.3-2 and corrected previously published URL for 2015.2-2 that suddenly changed 'back' to 2015.2.