### PR TITLE
Correct ver. no and full_name of gedit.sls

### DIFF
--- a/gedit.sls
+++ b/gedit.sls
@@ -1,7 +1,7 @@
 gedit:
-  2.30.1.1:
+  2.30.1-1:
     installer: http://ftp.gnome.org/pub/GNOME/binaries/win32/gedit/2.30/gedit-setup-2.30.1-1.exe
-    full_name: Gedit 2.30.1.1
+    full_name: Gedit 2.30.1
     locale: en_US
     reboot: False
     install_flags: ' /sp- /verysilent /norestart'


### PR DESCRIPTION
Corrected ver no and full_name of gedit.sls. The add/remove name was wrong, as was sls file version number.