### PR TITLE
Correct putty.sls windows full_name

### DIFF
--- a/putty.sls
+++ b/putty.sls
@@ -1,21 +1,21 @@
 putty:
   0.64:
     installer: 'http://the.earth.li/~sgtatham/putty/0.64/x86/putty-0.64-installer.exe'
-    full_name:  'PuTTY version 0.64'
+    full_name:  'PuTTY release 0.64'
     reboot: False
     install_flags: '/sp- /verysilent'
     uninstaller: '%PROGRAMFILES(x86)%\PuTTY\unins000.exe'
     uninstall_flags: '/sp- /verysilent /norestart'
   0.63:
     installer: 'http://the.earth.li/~sgtatham/putty/0.63/x86/putty-0.63-installer.exe'
-    full_name:  'PuTTY version 0.63'
+    full_name:  'PuTTY release 0.63'
     reboot: False
     install_flags: '/sp- /verysilent'
     uninstaller: '%PROGRAMFILES(x86)%\PuTTY\unins000.exe'
     uninstall_flags: '/sp- /verysilent /norestart'
   0.62:
     installer: 'http://the.earth.li/~sgtatham/putty/0.62/x86/putty-0.62-installer.exe'
-    full_name: 'PuTTY version 0.62'
+    full_name: 'PuTTY release 0.62'
     reboot: False
     install_flags: '/sp- /verysilent'
     uninstaller: '%PROGRAMFILES(x86)%\PuTTY\unins000.exe'


### PR DESCRIPTION
Correct putty.sls windows full_name to use the word windows actually uses 'release' and not the previously present one 'version'