### PR TITLE
Correct pdf24creator.sls windows full_name

### DIFF
--- a/pdf24creator.sls
+++ b/pdf24creator.sls
@@ -3,10 +3,9 @@
 pdf24creator:
   6.9.2.0:
     installer: 'http://stx.pdf24.org/products/pdf-creator/download/pdf24-creator-6.9.2.msi'
-    full_name: 'pdf24creator'
+    full_name: 'PDF24 Creator'
     reboot: False
     install_flags: 'DESKTOPICONS=No FAXPRINTER=No /norestart /qn'
     msiexec: True
     uninstaller: 'msiexec.exe'
     uninstall_flags: '/qn /x {6BDC67D0-567D-45A8-AE5E-2697DAF7B4E0}'
-  


### PR DESCRIPTION
Corrected pdf24creator.sls windows full_name, as it was, the package was not being recognised as ever being successfully installed.