### PR TITLE
Update chrome.sls ver. 66.77.16516

### DIFF
--- a/chrome.sls
+++ b/chrome.sls
@@ -1,10 +1,10 @@
 # Source: http://www.google.nl/intl/en/chrome/business/browser/admin/
 chrome:
-  66.41.32862:
+  66.77.16516:
     installer: 'https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi'
     full_name: 'Google Chrome'
     reboot: False
     install_flags: '/qn /norestart'
     msiexec: True
-    uninstaller: 'https://dl.google.com/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi'
-    uninstall_flags: '/qn'
+    uninstaller: 'msiexec.exe'
+    uninstall_flags: '/qn /x {2CF484F9-A0CD-3AD9-84A6-DFFE749FC71F}'


### PR DESCRIPTION
Updated chrome.sls ver. 66.77.16516, the old way of un-installing had it's problems. This new way also has limitations. Google only release a single URL and the version can (and does) change failry frequently. Which then means the un-installer GUID will be different. I will endeveour to check this more frequently than in the past.