### PR TITLE
fix case of passware-kit-agent.sls to all lowercase

### DIFF
--- a/passware-kit-agent.sls
+++ b/passware-kit-agent.sls
@@ -1,4 +1,4 @@
-Passware Kit Agent:
+passware-kit-agent:
   13.1.7657:
     full_name: 'Passware Kit Agent (64-bit)'
     msiexec: True


### PR DESCRIPTION
fixed case of passware-kit-agent.sls to all lowercase
@dkarpo dkarpo@gmail.com are you OK with this pkg name to be all lowercased?