### PR TITLE
fix case of passware-kit-forensic pkg to all lowercase

### DIFF
--- a/passware-kit-forensic.sls
+++ b/passware-kit-forensic.sls
@@ -1,4 +1,4 @@
-Passware Kit Forensic:
+passware-kit-forensic:
   13.1.7657:
     full_name: 'Passware Kit Forensic (64-bit)'
     msiexec: True


### PR DESCRIPTION
fixed case of passware-kit-forensic pkg to all lowercase
@dkarpo dkarpo@gmail.com are you OK with the pkg name to be all lowercased?