### PR TITLE
Clean putty_x86.sls remove old versions

### DIFF
--- a/putty_x86.sls
+++ b/putty_x86.sls
@@ -6,17 +6,3 @@ putty_x86:
     install_flags: '/sp- /verysilent'
     uninstaller: '%PROGRAMFILES%\PuTTY\unins000.exe'
     uninstall_flags: '/sp- /verysilent /norestart'
-  0.63:
-    installer: 'http://the.earth.li/~sgtatham/putty/0.63/x86/putty-0.63-installer.exe'
-    full_name:  'PuTTY release 0.63'
-    reboot: False
-    install_flags: '/sp- /verysilent'
-    uninstaller: '%PROGRAMFILES%\PuTTY\unins000.exe'
-    uninstall_flags: '/sp- /verysilent /norestart'
-  0.62:
-    installer: 'http://the.earth.li/~sgtatham/putty/0.62/x86/putty-0.62-installer.exe'
-    full_name: 'PuTTY release 0.62'
-    reboot: False
-    install_flags: '/sp- /verysilent'
-    uninstaller: '%PROGRAMFILES%\PuTTY\unins000.exe'
-    uninstall_flags: '/sp- /verysilent /norestart'    


### PR DESCRIPTION
Cleaned putty_x86.sls remove old versions, no sense in keeping old unsecure versions around.