### PR TITLE
Fix windirstat.sls mismatched version number

### DIFF
--- a/windirstat.sls
+++ b/windirstat.sls
@@ -1,5 +1,5 @@
 windirstat:
-  1.1.2.80:
+  1.1.2:
     installer: 'http://prdownloads.sourceforge.net/windirstat/windirstat1_1_2_setup.exe'
     full_name: 'WinDirStat 1.1.2'
     reboot: False


### PR DESCRIPTION
Fixed windirstat.sls mismatched version number, it did not match windows idea of it's version number