### PR TITLE
Correct exact version number string for keepass.sls to 1.29.0

### DIFF
--- a/keepass.sls
+++ b/keepass.sls
@@ -1,5 +1,5 @@
 keepass-1x.sls:
-  1.29:
+  1.29.0:
     installer: 'http://vorboss.dl.sourceforge.net/project/keepass/KeePass%201.x/1.29/KeePass-1.29.msi'
     full_name: 'KeePass 1.29'
     reboot: False


### PR DESCRIPTION
Corrected exact version number string for keepass.sls to 1.29.0