### PR TITLE
Delete adobereader_dc-mui.sls

### DIFF
--- a/adobereader_dc-mui.sls
+++ b/adobereader_dc-mui.sls
@@ -1,9 +1,0 @@
-adobereader_dc-mui:
-  2015.007.20033:
-    full_name: 'Adobe Reader DC MUI'
-    installer: 'http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/1500720033/AcroRdrDC1500720033_MUI.exe'
-    reboot: False
-    locale: en_US
-    install_flags: ' /msi EULA_ACCEPT=YES REMOVE_PREVIOUS=YES /qn'
-    uninstaller: 'msiexec.exe'
-    uninstall_flags: '/qn /x {AC76BA86-7AD7-FFFF-7B44-AC0F074E4100}'


### PR DESCRIPTION
Deleted adobereader_dc-mui.sls, the dc-mui line is hard to keep up to date as it requires slipstreaming msp files. so this line is ebing retired and instead the adobereader-dc.sls line will be maintained.