### PR TITLE
Add missing ver number to registry

### DIFF
--- a/windirstat_x86.sls
+++ b/windirstat_x86.sls
@@ -4,6 +4,9 @@ windirstat_x86:
     installer: 'http://heanet.dl.sourceforge.net/project/windirstat/windirstat/1.1.2%20installer%20re-release%20(more%20languages!)/windirstat1_1_2_setup.exe'
     full_name: 'WinDirStat 1.1.2'
     reboot: False
-    install_flags: '/S'
+    install_flags: |
+                   '/S &
+                   reg ADD HKU\.DEFAULT\Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat /v DisplayVersion /d 1.1.2
+                   exit 0'
     uninstaller: '%ProgramFiles%\WinDirStat\uninstall.exe'
     uninstall_flags: '/S'


### PR DESCRIPTION
Add missing ver number to registry, so that the winrepo installer finds both the full_name AND the version match