### PR TITLE
Update clink ver 4 (all released versions)

### DIFF
--- a/clink.sls
+++ b/clink.sls
@@ -32,6 +32,6 @@ clink:
     full_name: 'Clink v0.4'
     reboot: False
     install_flags: '/S'
-    uninstaller: '%Program Files (x86)%\clink\0.4.3\clink_uninstall_0.4.3.exe'
+    uninstaller: '%Program Files (x86)%\clink\0.4\clink_uninstall_0.4.exe'
     uninstall_flags: '/S'
 # https://mridgers.github.io/clink/

--- a/clink.sls
+++ b/clink.sls
@@ -13,4 +13,25 @@ clink:
     install_flags: '/S'
     uninstaller: '%Program Files (x86)%\clink\0.4.3\clink_uninstall_0.4.3.exe'
     uninstall_flags: '/S'
+  0.4.2:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4.2/clink_0.4.2_setup.exe'
+    full_name: 'Clink v0.4.2'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files (x86)%\clink\0.4.2\clink_uninstall_0.4.2.exe'
+    uninstall_flags: '/S'
+  0.4.1:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4.1/clink_0.4.1_setup.exe'
+    full_name: 'Clink v0.4.1'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files (x86)%\clink\0.4.1\clink_uninstall_0.4.1.exe'
+    uninstall_flags: '/S'
+  0.4:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4/clink_0.4_setup.exe'
+    full_name: 'Clink v0.4'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files (x86)%\clink\0.4.3\clink_uninstall_0.4.3.exe'
+    uninstall_flags: '/S'
 # https://mridgers.github.io/clink/

--- a/clink_x86.sls
+++ b/clink_x86.sls
@@ -13,4 +13,25 @@ clink_x86:
     install_flags: '/S'
     uninstaller: '%Program Files%\clink\0.4.3\clink_uninstall_0.4.3.exe'
     uninstall_flags: '/S'
+  0.4.2:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4.2/clink_0.4.2_setup.exe'
+    full_name: 'Clink v0.4.2'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files%\clink\0.4.2\clink_uninstall_0.4.2.exe'
+    uninstall_flags: '/S'
+  0.4.1:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4.1/clink_0.4.1_setup.exe'
+    full_name: 'Clink v0.4.1'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files%\clink\0.4.1\clink_uninstall_0.4.1.exe'
+    uninstall_flags: '/S'
+  0.4:
+    installer: 'https://github.com/mridgers/clink/releases/download/0.4/clink_0.4_setup.exe'
+    full_name: 'Clink v0.4'
+    reboot: False
+    install_flags: '/S'
+    uninstaller: '%Program Files%\clink\0.4\clink_uninstall_0.4.exe'
+    uninstall_flags: '/S'    
 # https://mridgers.github.io/clink/


### PR DESCRIPTION
Updated to have all clink ver 4 releases in this file, want to use it as a sample to add jijnja snippets in, to create a unified winrepo sls that windows salt-minions from Berrilium (>= 2015.8) or higher can interpret in real-time.  