### PR TITLE
Create initial snmptools.sls and snmptools_x86.sls

### DIFF
--- a/snmptools.sls
+++ b/snmptools.sls
@@ -1,0 +1,10 @@
+snmptools:
+  Not Found:
+    full_name:  'SnmpTools 2'
+    installer: 'http://erwan.labalec.fr/snmptools/snmptools32.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES(x86)%\SnmpTools\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False

--- a/snmptools_x86.sls
+++ b/snmptools_x86.sls
@@ -1,0 +1,10 @@
+snmptools_x86:
+  Not Found:
+    full_name:  'SnmpTools 2'
+    installer: 'http://erwan.labalec.fr/snmptools/snmptools32.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SnmpTools\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
The SnmpTools installer doesn't populate the DisplayVersion, and pkg.version / pkg.list_pkgs reports the version as *Not Found*. Using *Not Found* as the version in the package file seems to work, with the pkg.* execution modules operating normally, and the pkg.installed state module correctly detecting when it's already installed (see [this Gist for an example](https://gist.github.com/m03/4b444666290574795ff7)). If there's a better official way to handle this, I can modify the package files accordingly.

---
SnmpTools is an snmp agent servicing all windows performance counters thus allowing tools such as MRTG or Cacti to retrieve windows performance values (cpu, memory, disk, etc.).

http://labalec.fr/erwan/?page_id=24