### PR TITLE
Bump golang version offerings to include 1.5

### DIFF
--- a/golang.sls
+++ b/golang.sls
@@ -1,4 +1,13 @@
 golang:
+  1.5:
+    full_name: 'Go 1.5 (64-bit)'
+    installer: 'https://storage.googleapis.com/golang/go1.5.windows-amd64.msi'
+    install_flags: '/qn /norestart'
+    uninstaller: 'https://storage.googleapis.com/golang/go1.5.windows-amd64.msi'
+    uninstall_flags: '/qn'
+    msiexec: True
+    locale: en_US
+    reboot: False
   1.4.2:
     full_name: 'Go 1.4.2 (64-bit)'
     installer: 'https://storage.googleapis.com/golang/go1.4.2.windows-amd64.msi'

--- a/golang_x86.sls
+++ b/golang_x86.sls
@@ -1,4 +1,13 @@
 golang_x86:
+  1.5:
+    full_name: 'Go 1.5'
+    installer: 'https://storage.googleapis.com/golang/go1.5.windows-386.msi'
+    uninstaller: 'https://storage.googleapis.com/golang/go1.5.windows-386.msi'
+    install_flags: '/qn /norestart'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
   1.4.2:
     full_name: 'Go 1.4.2'
     installer: 'https://storage.googleapis.com/golang/go1.4.2.windows-386.msi'


### PR DESCRIPTION
Consider identifying where the installer goes locally and using that rather than downloading uninstaller.