### PR TITLE
Create initial wix-toolset ver. 3.10.0.2103

### DIFF
--- a/wix-toolset.sls
+++ b/wix-toolset.sls
@@ -1,0 +1,10 @@
+wix-toolset:
+  3.10.0.2103:
+    full_name: 'WiX Toolset v3.10.0.2103'
+    installer: 'https://wix.codeplex.com/downloads/get/1483377#'
+    install_flags: '/q'
+    uninstaller: '%ProgramData%\Package Cache\{229c8b18-b30c-409e-a47f-7d11c10aebb7}\WiX310.exe'
+    uninstall_flags: '/uninstall /q'
+    msiexec: False
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
This download URL does not end in the name of the installer, and therefore the downloaded file can't be executed 'as-is' in this case it downloads a file called '1483377#'

