### PR TITLE
Fix for #586, NSClient++ URL updates

### DIFF
--- a/nsclient.sls
+++ b/nsclient.sls
@@ -18,12 +18,3 @@ nsclient:
       msiexec: True
       locale: en_US
       reboot: False
-  '0.3.9.328':
-      full_name:  'NSClient++ (x64)'
-      installer: 'https://github.com/mickem/nscp/releases/download/0.3.9.328/NSCP-0.3.9.32-x64.msi'
-      install_flags: '/quiet'
-      uninstaller: 'https://github.com/mickem/nscp/releases/download/0.3.9.328/NSCP-0.3.9.32-x64.msi'
-      uninstall_flags: '/quiet'
-      msiexec: True
-      locale: en_US
-      reboot: False

--- a/nsclient.sls
+++ b/nsclient.sls
@@ -1,19 +1,29 @@
 nsclient:
+  '0.4.3.143':
+    # This client can be currently be downloaded from https://github.com/mickem/nscp/releases/download/0.4.3.143/NSCP-0.4.3.143-x64.msi
+    full_name:  'NSClient++ (x64)'
+    installer: 'salt://win/repo/nsclientpp/NSCP-0.4.3.143-x64.msi'
+    install_flags: '/quiet'
+    uninstaller: 'salt://win/repo/nsclientpp/NSCP-0.4.3.143-x64.msi'
+    uninstall_flags: '/quiet'
+    msiexec: True
+    locale: en_US
+    reboot: False
   '0.4.3.88':
-    full_name:  'NSClient++ (x64)'
-    installer: 'http://files.nsclient.org/released/NSCP-0.4.3.88-x64.msi'
-    install_flags: '/quiet'
-    uninstaller: 'http://files.nsclient.org/released/NSCP-0.4.3.88-x64.msi'
-    uninstall_flags: '/quiet'
-    msiexec: True
-    locale: en_US
-    reboot: False
+      full_name:  'NSClient++ (x64)'
+      installer: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-x64.msi'
+      install_flags: '/quiet'
+      uninstaller: 'https://github.com/mickem/nscp/releases/download/0.4.3.88/NSCP-0.4.3.88-x64.msi'
+      uninstall_flags: '/quiet'
+      msiexec: True
+      locale: en_US
+      reboot: False
   '0.3.9.328':
-    full_name:  'NSClient++ (x64)'
-    installer: 'http://files.nsclient.org/0.3.x/NSClient%2B%2B-0.3.9-x64.msi'
-    install_flags: '/quiet'
-    uninstaller: 'http://files.nsclient.org/0.3.x/NSClient%2B%2B-0.3.9-x64.msi'
-    uninstall_flags: '/quiet'
-    msiexec: True
-    locale: en_US
-    reboot: False
+      full_name:  'NSClient++ (x64)'
+      installer: 'https://github.com/mickem/nscp/releases/download/0.3.9.328/NSCP-0.3.9.32-x64.msi'
+      install_flags: '/quiet'
+      uninstaller: 'https://github.com/mickem/nscp/releases/download/0.3.9.328/NSCP-0.3.9.32-x64.msi'
+      uninstall_flags: '/quiet'
+      msiexec: True
+      locale: en_US
+      reboot: False


### PR DESCRIPTION
Update the installer/uninstaller URLs for the existing nsclient versions, these recently changed and broke this package sls. I'm choosing not to swap the existing versions to salt:// references since that would be a pretty confusing change for people currently using the formula.

However, I've also added the most recent nsclient version with a salt:// reference. It's much better to force the administrator to locally host the installer than to force them to use a link that is likely to break at some indefinite point in the future. For all new versions going forward, I would strongly recommend doing this.

Fixes #586