### PR TITLE
Downgrade git to ver. 2.6.2

### DIFF
--- a/git.sls
+++ b/git.sls
@@ -1,13 +1,4 @@
 git:
-  '2.6.3':
-    full_name: 'Git version 2.6.3'
-    installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.3.windows.1/Git-2.6.3-64-bit.exe'
-    install_flags: '/VERYSILENT /NORESTART /SP- /NOCANCEL'
-    uninstaller: '%ProgramFiles%\Git\unins000.exe'
-    uninstall_flags: '/VERYSILENT /NORESTART & %ProgramFiles(x86)%\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '2.6.2':
     full_name: 'Git version 2.6.2'
     installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.2.windows.1/Git-2.6.2-64-bit.exe'

--- a/git_x86.sls
+++ b/git_x86.sls
@@ -1,13 +1,4 @@
 git_x86:
-  '2.6.3':
-    full_name: 'Git version 2.6.3'
-    installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.3.windows.1/Git-2.6.3-32-bit.exe'
-    install_flags: '/VERYSILENT /NORESTART /SP- /NOCANCEL'
-    uninstaller: '%ProgramFiles%\Git\unins000.exe'
-    uninstall_flags: '/VERYSILENT /NORESTART & %ProgramFiles%\Git\unins001.exe /VERYSILENT /NORESTART & exit 0'
-    msiexec: False
-    locale: en_US
-    reboot: False
   '2.6.2':
     full_name: 'Git version 2.6.2'
     installer: 'https://github.com/git-for-windows/git/releases/download/v2.6.2.windows.1/Git-2.6.2-32-bit.exe'


### PR DESCRIPTION
ver. 2.6.3 had an installation regression see https://github.com/saltstack/salt-winrepo-ng/issues/142