### PR TITLE
Create initial icecast.sls 2.4.2

### DIFF
--- a/icecast.sls
+++ b/icecast.sls
@@ -1,0 +1,11 @@
+icecast:
+  '2.4.2': 
+    full_name: 'Icecast'
+    installer: 'http://downloads.xiph.org/releases/icecast/icecast_win32_2.4.2.exe'
+    install_flags: '/S'
+    uninstaller: '%PROGRAMFILES(x86)%\Icecast\Uninstall.exe'
+    uninstall_flags: '/S'
+    msiexec: False
+    locale: en_US
+    reboot: False
+

--- a/icecast_x86.sls
+++ b/icecast_x86.sls
@@ -1,0 +1,11 @@
+icecast_x86:
+  '2.4.2': 
+    full_name: 'Icecast'
+    installer: 'http://downloads.xiph.org/releases/icecast/icecast_win32_2.4.2.exe'
+    install_flags: '/S'
+    uninstaller: '%PROGRAMFILES%\Icecast\Uninstall.exe'
+    uninstall_flags: '/S'
+    msiexec: False
+    locale: en_US
+    reboot: False
+


### PR DESCRIPTION
Icecast is a streaming media server which currently supports Ogg (Vorbis and Theora), Opus, WebM and MP3 audio streams.

http://icecast.org/

Tested on Windows 2012r2 running salt-minion 2015.5.8.