### PR TITLE
Update stunnel to ver. 5.29

### DIFF
--- a/stunnel.sls
+++ b/stunnel.sls
@@ -1,7 +1,7 @@
 stunnel:
-  Not Found:
-    full_name: 'stunnel'
-    installer: 'https://www.stunnel.org/downloads/stunnel-5.22-installer.exe'
+  '5.29':
+    full_name: 'stunnel installed for AllUsers'
+    installer: 'https://www.stunnel.org/downloads/stunnel-5.29-installer.exe'
     install_flags: '/S'
     uninstaller: '%PROGRAMFILES(x86)%\stunnel\uninstall.exe'
     uninstall_flags: '/S'

--- a/stunnel_x86.sls
+++ b/stunnel_x86.sls
@@ -1,7 +1,7 @@
 stunnel_x86:
-  Not Found:
-    full_name: 'stunnel'
-    installer: 'https://www.stunnel.org/downloads/stunnel-5.22-installer.exe'
+  '5.29':
+    full_name: 'stunnel installed for AllUsers'
+    installer: 'https://www.stunnel.org/downloads/stunnel-5.29-installer.exe'
     install_flags: '/S'
     uninstaller: '%PROGRAMFILES%\stunnel\uninstall.exe'
     uninstall_flags: '/S'


### PR DESCRIPTION
**Changes**

* Update stunnel to current 5.29 version.
* See https://www.stunnel.org/downloads.html

**Testing**

* Tested on Windows 2012r2 running salt-minion 2015.5.8.