### PR TITLE
Create initial cyberduck-cli.sls 1.0.0.0

### DIFF
--- a/cyberduck-cli.sls
+++ b/cyberduck-cli.sls
@@ -1,0 +1,11 @@
+cyberduck-cli:
+  '1.0.0.0': 
+    full_name: 'Cyberduck CLI'
+    installer: 'http://dist.duck.sh/duck-4.8.0.18560.exe'
+    install_flags: '/quiet /norestart'
+    uninstaller: '%ALLUSERSPROFILE%\Package Cache\{546f46a5-c136-46d7-9698-8bd02eea4402}\duck-4.8.0.18560.exe'
+    uninstall_flags: '/uninstall /quiet /norestart'
+    msiexec: False
+    locale: en_US
+    reboot: False
+


### PR DESCRIPTION
Cyberduck for the command line interface (CLI).

https://duck.sh/?l=en

Tested on Windows 2012r2 running salt-minion 2015.5.8.