### PR TITLE
Update vagrant.sls

### DIFF
--- a/vagrant.sls
+++ b/vagrant.sls
@@ -1,135 +1,153 @@
 vagrant:
-  '1.7.4':
-    full_name: 'Vagrant 1.7.4 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.msi'
+  '1.8.1':
+    full_name: 'Vagrant'
+    installer: 'https://dl.bintray.com/mitchellh/vagrant/1.8.1/vagrant_1.8.1.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1.msi'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
+  '1.8.0':
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.8.0/vagrant_1.8.0.msi'
+    install_flags: '/qn /norestart'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.8.0/vagrant_1.8.0.msi'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False
+  '1.7.4':
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi'
+    install_flags: '/qn /norestart'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.7.3':
-    full_name: 'Vagrant 1.7.3 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.3.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.7.3/vagrant_1.7.3.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.3.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.7.3/vagrant_1.7.3.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.7.2':
-    full_name: 'Vagrant 1.7.2 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.7.2/vagrant_1.7.2.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.7.2/vagrant_1.7.2.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.7.1':
-    full_name: 'Vagrant 1.7.1 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.1.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.7.1/vagrant_1.7.1.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.1.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.7.1/vagrant_1.7.1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.5':
-    full_name: 'Vagrant 1.6.5 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.5/vagrant_1.6.5.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.5.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.6.5/vagrant_1.6.5.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.4':
-    full_name: 'Vagrant 1.6.4 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.4.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.4/vagrant_1.6.4.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.4.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.6.4/vagrant_1.6.4.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.3':
-    full_name: 'Vagrant 1.6.3 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.3/vagrant_1.6.3.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.3.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/vagrant_1.6.3.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.2':
-    full_name: 'Vagrant 1.6.2 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.2.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.2/vagrant_1.6.2.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.2.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.6.2/vagrant_1.6.2.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.1':
-    full_name: 'Vagrant 1.6.1 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.1.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.1/vagrant_1.6.1.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.1.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.6.1/vagrant_1.6.1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.6.0':
-    full_name: 'Vagrant 1.6.0 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.0.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.6.0/vagrant_1.6.0.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.6.0.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.6.0/vagrant_1.6.0.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.5.4':
-    full_name: 'Vagrant 1.5.4 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.4.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.5.4/vagrant_1.5.4.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.4.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.5.4/vagrant_1.5.4.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.5.3':
-    full_name: 'Vagrant 1.5.3 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.3.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.5.3/vagrant_1.5.3.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.3.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.5.3/vagrant_1.5.3.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.5.2':
-    full_name: 'Vagrant 1.5.2 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.2.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.5.2/vagrant_1.5.2.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.2.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.5.2/vagrant_1.5.2.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.5.1':
-    full_name: 'Vagrant 1.5.1 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.1.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.5.1/vagrant_1.5.1.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.1.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.5.1/vagrant_1.5.1.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US
     reboot: False
   '1.5.0':
-    full_name: 'Vagrant 1.5.0 Universal (32 and 64-bit)'
-    installer: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.0.msi'
+    full_name: 'Vagrant'
+    installer: 'https://releases.hashicorp.com/vagrant/1.5.0/vagrant_1.5.0.msi'
     install_flags: '/qn /norestart'
-    uninstaller: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.0.msi'
+    uninstaller: 'https://releases.hashicorp.com/vagrant/1.5.0/vagrant_1.5.0.msi'
     uninstall_flags: '/qn /norestart'
     msiexec: True
     locale: en_US


### PR DESCRIPTION
Vagrant. Added versions 1.8.1, 1.8.0. Previous URLs not available now and they will be changed to official download links. Full name changed.