### PR TITLE
Create initial aspnet-mvc1 1.0.0.0

### DIFF
--- a/aspnet-mvc1.sls
+++ b/aspnet-mvc1.sls
@@ -1,0 +1,10 @@
+aspnet-mvc1:
+  '1.0.0.0':
+    full_name: 'Microsoft ASP.NET MVC 1.0'
+    installer: 'https://download.microsoft.com/download/A/6/8/A68968AE-DE1D-4FA4-A98A-B74042C6090D/AspNetMVC1.msi'
+    install_flags: '/qn /norestart' 
+    uninstaller: '{A4394612-D02F-11DC-9BFF-D18556D89593}'
+    uninstall_flags: '/qn /norestart'
+    msiexec: True
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
ASP.NET MVC 1.0 provides a new Model-View-Controller (MVC) framework on top of the existing ASP.NET 3.5 runtime.

https://www.microsoft.com/en-us/download/details.aspx?id=5388

Tested install on Windows 2012r2 running salt-minion 2015.5.8.
