### PR TITLE
Create initial SSC Serv Free 3.6.1

### DIFF
--- a/sscserv-free.sls
+++ b/sscserv-free.sls
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+sscserv-free:
+  '3.6.1':
+    full_name: 'SSC Serv 3.6.1 Free Edition'
+    installer: 'http://ssc-serv.com/files/SSC%20Serv%20Setup%203.6.1%20x86-64%20Free%20Edition.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SSC Serv\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False
+  '3.5.0':
+    full_name: 'SSC Serv 3.5.0 Free Edition'
+    installer: 'http://ssc-serv.com/files/SSC%20Serv%20Setup%203.5.0%20x86-64%20Free%20Edition.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SSC Serv\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False

--- a/sscserv-free_x86.sls
+++ b/sscserv-free_x86.sls
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+sscserv-free_x86:
+  '3.6.1':
+    full_name: 'SSC Serv 3.6.1 Free Edition'
+    installer: 'http://ssc-serv.com/files/SSC%20Serv%20Setup%203.6.1%20x86%20Free%20Edition.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SSC Serv\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False
+  '3.5.0':
+    full_name: 'SSC Serv 3.5.0 Free Edition'
+    installer: 'http://ssc-serv.com/files/SSC%20Serv%20Setup%203.5.0%20x86%20Free%20Edition.exe'
+    install_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    uninstaller: '%PROGRAMFILES%\SSC Serv\unins000.exe'
+    uninstall_flags: '/SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART'
+    msiexec: False
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
SSC Serv is a service for Microsoft Windows, which collects system statistics and submits them to a central statistics server. It is similar to and compatible with collectd, a free and open-sourced solution for UNIX systems.

https://ssc-serv.com/features.shtml

Tested on Windows 2012r2.