### PR TITLE
Remove duplicate 2015.5.6 entry

### DIFF
--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -98,7 +98,17 @@ salt-minion:
     refresh: true
     msiexec: False
     locale: en_US
-    reboot: False 
+    reboot: False
+ '2015.5.7':
+    full_name: 'Salt Minion 2015.5.7'
+    installer: 'https://repo.saltstack.com/windows/Salt-Minion-2015.5.7-AMD64-Setup.exe'
+    install_flags: '/S'
+    uninstaller: 'C:\salt\uninst.exe'
+    uninstall_flags: '/S'
+    refresh: true
+    msiexec: False
+    locale: en_US
+    reboot: False
   '2015.5.6':
     full_name: 'Salt Minion 2015.5.6'
     installer: 'https://repo.saltstack.com/windows/Salt-Minion-2015.5.6-AMD64-Setup.exe'

--- a/salt-minion.sls
+++ b/salt-minion.sls
@@ -108,16 +108,6 @@ salt-minion:
     refresh: true
     msiexec: False
     locale: en_US
-    reboot: False 
-  '2015.5.6':
-    full_name: 'Salt Minion 2015.5.6'
-    installer: 'https://repo.saltstack.com/windows/Salt-Minion-2015.5.6-AMD64-Setup.exe'
-    install_flags: '/S'
-    uninstaller: 'C:\salt\uninst.exe'
-    uninstall_flags: '/S'
-    refresh: true
-    msiexec: False
-    locale: en_US
     reboot: False
   '2015.5.5':
     full_name: 'Salt Minion 2015.5.5'


### PR DESCRIPTION
There was a double entry for version 2015.5.6 in salt-minion.sls. I guess that one of those two entries was really supposed to have been 2015.5.7, so I made the change and made this pull request. BTW salt-minion.sls is not compiling for me (with winrepo.genrepo) in 2015.8.8.2 for this reason.