### PR TITLE
Zabbix Agent installer

### DIFF
--- a/zabbix-agent.sls
+++ b/zabbix-agent.sls
@@ -1,4 +1,4 @@
-zabbix_agent:
+zabbix-agent:
   4.2.3.2400:
     {% if grains['cpuarch'] == 'AMD64' %}
     full_name: 'Zabbix Agent (64-bit)'

--- a/zabbix_agent.sls
+++ b/zabbix_agent.sls
@@ -1,0 +1,25 @@
+zabbix_agent:
+  4.2.3.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/4.2.3/zabbix_agent-4.2.3-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False
+  4.0.9.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/4.0.9/zabbix_agent-4.0.9-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False
+  3.0.28.2400:
+    {% if grains['cpuarch'] == 'AMD64' %}
+    full_name: 'Zabbix Agent (64-bit)'
+    installer: 'https://www.zabbix.com/downloads/3.0.28/zabbix_agent-3.0.28-win-amd64-openssl.msi'
+    {% endif %}
+    install_flags: '/quiet SERVER=localhost'
+    locale: en_US
+    reboot: False


### PR DESCRIPTION
Currently this only works for x64 based windows as I don't have a x86 based windows server and the agent won't allow you to do an x86 based install on the x64 based server.

Also I have been unable to get the agent to uninstall via cli in quiet mode properly, windows tells me the client is not installed or other things and so the uninstall fails unless you do a full removal from the windows programs and features center.